### PR TITLE
Update interface

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,10 +1,23 @@
 requires            "OpenTracing::GlobalTracer";
-
 requires            "Carp";
 requires            "Module::Load";
 requires            "Role::Declare::Should";
 requires            "Types::Standard";
 
+recommends          "OpenTracing::Implementation::NoOp";
+
+
+
+on 'develop' => sub {
+    requires            "ExtUtils::MakeMaker::CPANfile";
+};
+
+
+
 on 'test' => sub {
+    requires            "OpenTracing::Interface::Tracer";
+    requires            "OpenTracing::Implementation::NoOp";
+    requires            "Role::Tiny::With";
     requires            "Test::Most";
+    requires            "Module::Loaded";
 };

--- a/lib/OpenTracing/Implementation/Interface/Bootstrap.pm
+++ b/lib/OpenTracing/Implementation/Interface/Bootstrap.pm
@@ -1,11 +1,13 @@
 package OpenTracing::Implementation::Interface::Bootstrap;
 
 use Role::Declare::Should;
-use Types::Standard qw/ConsumerOf/;
+use Types::Standard qw/Any ConsumerOf Maybe Str/;
 
 
 
 class_method bootstrap_tracer(
+    Str $implementation_name,
+    Maybe [ Any ] @implementation_args,
 ) :Return ( ConsumerOf['OpenTracing::Interface::Tracer'] ) { }
 
 

--- a/t/10_bootstrap.t
+++ b/t/10_bootstrap.t
@@ -1,0 +1,131 @@
+use Test::Most;
+
+use OpenTracing::Implementation;
+
+local $ENV{OPENTRACING_IMPLEMENTATION} = '+MyTest::Default';
+
+# _build_tracer will try to `load` these from disk
+#
+use Module::Loaded;
+mark_as_loaded( MyTest::Implementation );
+mark_as_loaded( MyTest::Default );
+
+
+
+our @test_params;
+
+
+
+subtest "pass on arguments for 'bootstrap_tracer'" => sub {
+    
+    undef @test_params;
+    
+    lives_ok {
+        my $tracer = OpenTracing::Implementation->bootstrap_tracer(
+            '+MyTest::Implementation',
+            foo => 1,
+            qw/more/
+        )
+    } "Can call method 'bootstrap_tracer'";
+    
+    cmp_deeply(
+        \@test_params => [
+            [ 'MyTest::Implementation', 'foo', 1, 'more' ]
+        ], "... and passes on the right params to 'MyTest::Implementation"
+    );
+    
+};
+
+
+
+subtest "pass on arguments for 'bootstrap_default_tracer'" => sub {
+    
+    undef @test_params;
+    
+    lives_ok {
+        my $tracer = OpenTracing::Implementation->bootstrap_default_tracer(
+            bar => 2,
+            qw/more here/
+        )
+    } "Can call method 'bootstrap_default_tracer'";
+    
+    cmp_deeply(
+        \@test_params => [
+            [ 'MyTest::Default', 'bar', 2, 'more', 'here' ]
+        ], "... and passes on the right params to 'MyTest::Default"
+    );
+    
+};
+
+
+
+subtest "pass on arguments for 'bootstrap_global_tracer'" => sub {
+    
+    undef @test_params;
+    
+    lives_ok {
+        my $tracer = OpenTracing::Implementation->bootstrap_global_tracer(
+            '+MyTest::Implementation',
+            baz => 3,
+            qw/and more/
+        )
+    } "Can call method 'bootstrap_global_tracer'";
+    
+    cmp_deeply(
+        \@test_params => [
+            [ 'MyTest::Implementation', 'baz', 3, 'and', 'more' ]
+        ], "... and passes on the right params to 'MyTest::Implementation"
+    );
+    
+};
+
+
+
+done_testing();
+
+
+
+package MyTest::Implementation;
+
+sub bootstrap_tracer {
+    push @main::test_params, [ @_ ];
+    
+    bless {}, 'MyStub::Tracer'
+}
+
+BEGIN {
+    use Role::Tiny::With;
+    with 'OpenTracing::Implementation::Interface::Bootstrap'
+} # check at compile time, perl -c will work
+
+
+
+package MyTest::Default;
+
+sub bootstrap_tracer {
+    push @main::test_params, [ @_ ];
+    
+    bless {}, 'MyStub::Tracer'
+}
+
+BEGIN {
+    use Role::Tiny::With;
+    with 'OpenTracing::Implementation::Interface::Bootstrap'
+} # check at compile time, perl -c will work
+
+
+
+package MyStub::Tracer;
+
+
+sub get_scope_manager { ... }
+sub get_active_span { ... }
+sub start_active_span { ... }
+sub start_span { ... }
+sub inject_context { ... }
+sub extract_context { ... }
+
+BEGIN {
+    use Role::Tiny::With;
+    with 'OpenTracing::Interface::Tracer'
+} # check at compile time, perl -c will work


### PR DESCRIPTION
This wil fix an issue we had with the underlying interface definition of `OpenTracing::Implementation::Interface::Bootdtrap`, not capable of handling any arguments.
