### PR TITLE
Clean up warnings during test

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -4,10 +4,6 @@ requires            "Module::Load";
 requires            "Role::Declare::Should";
 requires            "Types::Standard";
 
-recommends          "OpenTracing::Implementation::NoOp";
-
-
-
 on 'develop' => sub {
     requires            "ExtUtils::MakeMaker::CPANfile";
 };
@@ -16,7 +12,6 @@ on 'develop' => sub {
 
 on 'test' => sub {
     requires            "OpenTracing::Interface::Tracer";
-    requires            "OpenTracing::Implementation::NoOp";
     requires            "Role::Tiny::With";
     requires            "Test::Most";
     requires            "Module::Loaded";

--- a/lib/OpenTracing/Implementation.pm
+++ b/lib/OpenTracing/Implementation.pm
@@ -70,8 +70,6 @@ sub _build_tracer {
     carp "Loading implementation $implementation_class"
         if OT_DEBUG;
     
-    load $implementation_class;
-    
     eval { load $implementation_class };
     croak "GlobalTracer can't load implementation [$implementation_class]"
         if $@;

--- a/t/00_use_ok.t
+++ b/t/00_use_ok.t
@@ -1,5 +1,10 @@
 use Test::Most;
 
+BEGIN {
+    use Module::Loaded;
+    mark_as_loaded( OpenTracing::Implementation::NoOp::Tracer )
+}
+
 BEGIN { use_ok('OpenTracing::Implementation') };
 
 done_testing;

--- a/t/01_can_methods.t
+++ b/t/01_can_methods.t
@@ -1,5 +1,10 @@
 use Test::Most;
 
+BEGIN {
+    use Module::Loaded;
+    mark_as_loaded( OpenTracing::Implementation::NoOp::Tracer )
+}
+
 use OpenTracing::Implementation;
 
 

--- a/t/10_bootstrap.t
+++ b/t/10_bootstrap.t
@@ -1,10 +1,18 @@
 use Test::Most;
 
+BEGIN {
+    use Module::Loaded;
+    mark_as_loaded( OpenTracing::Implementation::NoOp::Tracer )
+    #
+    # underlying use OpenTracing::GlobalTracer import warns if it can not load the NoOp::Tracer
+}
+
 use OpenTracing::Implementation;
+
+use Module::Loaded;
 
 # _build_tracer will try to `load` these from disk
 #
-use Module::Loaded;
 mark_as_loaded( MyTest::Implementation );
 mark_as_loaded( MyTest::Default );
 mark_as_loaded( OpenTracing::Implementation::NoOp );


### PR DESCRIPTION
introduce a dirty way to shut up tests that do not have `NoOp::Tracer` installed